### PR TITLE
add lutron caseta custom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ My goals:
 * Google Pixel 2
 * iPhone 7
 * Liftmaster MyQ Garage Door opener
+* Lutron Caséta dimmers and Pico remotes
 * Nest thermostat, protects, cameras
 * Old Mac Mini to run [Home Assistant](https://home-assistant.io/)
 * Life360 (mobile device tracking)

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -196,6 +196,17 @@ camera:
     still_image_url: !secret kari_map_url
     limit_refetch_to_url_change: true
 
+# These IDs come from the JSON file that the Lutron app's "Send Integration Report"
+# option delivers. That file needs to be saved as ./caseta_[lutron_host_ip].json
+caseta:
+  bridges:
+  - host: !secret lutron_host_ip
+    devices:
+      - id: 2
+        type: dimmer
+      - id: 3
+        type: remote
+
 cover:
   - platform: myq
     type: liftmaster

--- a/custom_components/caseta/__init__.py
+++ b/custom_components/caseta/__init__.py
@@ -1,0 +1,212 @@
+from . import casetify
+import asyncio
+import weakref
+import logging
+import voluptuous as vol
+import os.path
+import json
+
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_DEVICES, CONF_HOST, CONF_TYPE)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import discovery
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "caseta"
+
+CONF_BUTTONS = "buttons"
+CONF_BRIDGES = "bridges"
+DEFAULT_TYPE = "dimmer"
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_BRIDGES): vol.All(cv.ensure_list, [
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Optional(CONF_DEVICES): vol.All(cv.ensure_list, [
+                    {
+                        vol.Required(CONF_ID): cv.positive_int,
+                        vol.Optional(CONF_NAME): cv.string,
+                        vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): vol.In(['dimmer', 'switch', 'remote']),
+                    }
+                ]),
+            }
+        ]),
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+def setup(hass, config):
+    # read integration report, caseta_HOST.json
+    if CONF_BRIDGES in config[DOMAIN]:
+        for bridge in config[DOMAIN][CONF_BRIDGES]:
+            devices = []
+            fname = os.path.join(hass.config.config_dir, "caseta_" + bridge[CONF_HOST] + ".json")
+            _LOGGER.debug("loading %s", fname)
+            with open(fname, encoding='utf-8') as conf_file:
+                integration = json.load(conf_file)
+                # print(integration)
+                if "LIPIdList" in integration:
+                    # lights and switches are in Zones
+                    if "Zones" in integration["LIPIdList"]:
+                        for zone in integration["LIPIdList"]["Zones"]:
+                            # print(zone)
+                            devices.append({CONF_ID: zone["ID"],
+                                            CONF_NAME: zone["Name"],
+                                            CONF_TYPE: "dimmer"})
+                    # remotes are in Devices, except ID 1 which is the bridge itself
+                    if "Devices" in integration["LIPIdList"]:
+                        for device in integration["LIPIdList"]["Devices"]:
+                            # print(device)
+                            if device["ID"] != 1 and "Buttons" in device:
+                                devices.append({CONF_ID: device["ID"],
+                                                CONF_NAME: device["Name"],
+                                                CONF_TYPE: "remote",
+                                                CONF_BUTTONS: [b["Number"] for b in device["Buttons"]]})
+            # patch up integration with devices
+            if CONF_DEVICES in bridge:
+                for device in bridge[CONF_DEVICES]:
+                    found = False
+                    for existing in devices:
+                        if device[CONF_ID] == existing[CONF_ID]:
+                            for k in device:
+                                existing[k] = device[k]
+                            found = True
+                            break
+                    if not found:
+                        devices.append(device)
+            _LOGGER.debug("patched %s", devices)
+
+            # sort devices based on device types
+            types = { "remote": [], "switch": [], "dimmer": [] }
+            for device in devices:
+                types[device["type"]].append(device)
+            # print(types)
+
+            # run discovery per type
+            for t in types:
+                component = t
+                if component == "dimmer":
+                    component = "light"
+                if component == "remote":
+                    component = "sensor"
+                discovery.load_platform(hass,
+                                        component,
+                                        DOMAIN,
+                                        { CONF_HOST: bridge[CONF_HOST],
+                                          CONF_DEVICES: types[t] },
+                                        config)
+
+    return True
+
+class Caseta:
+    class __Callback(object):
+        def __init__(self, callback):
+            """Create a new callback calling the method @callback"""
+            obj = callback.__self__
+            attr = callback.__func__.__name__
+            self.wref = weakref.ref(obj, self.object_deleted)
+            self.callback_attr = attr
+            self.token = None
+
+        @asyncio.coroutine
+        def call(self, *args, **kwargs):
+            obj = self.wref()
+            if obj:
+                attr = getattr(obj, self.callback_attr)
+                yield from attr(*args, **kwargs)
+
+        def object_deleted(self, wref):
+            """Called when callback expires"""
+            pass
+
+    class __Caseta:
+        _hosts = {}
+
+        def __init__(self, host):
+            self._host = host
+            self._casetify = None
+            self._hass = None
+            self._callbacks = []
+
+        def __str__(self):
+            return repr(self) + self._host
+
+        @asyncio.coroutine
+        def _readNext(self):
+            _LOGGER.debug("Reading caseta for host %s", self._host)
+            mode, integration, action, value = yield from self._casetify.read()
+            if mode == None:
+                _LOGGER.debug("Read no values from casetify")
+                self._hass.loop.create_task(self._readNext())
+                return
+            _LOGGER.debug("Read caseta for host %s: %s %d %d %f", self._host, mode, integration, action, value)
+            # walk callbacks
+            for callback in self._callbacks:
+                _LOGGER.debug("Invoking callback for host %s", self._host)
+                yield from callback.call(mode, integration, action, value)
+            self._hass.loop.create_task(self._readNext())
+
+        @asyncio.coroutine
+        def _ping(self):
+            yield from asyncio.sleep(60)
+            yield from self._casetify.ping()
+            self._hass.loop.create_task(self._ping())
+
+        @asyncio.coroutine
+        def open(self):
+            _LOGGER.debug("Opening caseta for host %s", self._host)
+            if self._casetify != None:
+                return True
+            _LOGGER.info("Opened caseta for host %s", self._host)
+            self._casetify = casetify.Casetify()
+            yield from self._casetify.open(self._host)
+            return True
+
+        @asyncio.coroutine
+        def write(self, mode, integration, action, value, *args):
+            if self._casetify == None:
+                return False
+            yield from self._casetify.write(mode, integration, action, value, *args)
+            return True
+
+        @asyncio.coroutine
+        def query(self, mode, integration, action):
+            if self._casetify == None:
+                return False
+            yield from self._casetify.query(mode, integration, action)
+            return True
+
+        def register(self, callback):
+            self._callbacks.append(Caseta.__Callback(callback))
+
+        def start(self, hass):
+            _LOGGER.debug("Starting caseta for host %s", self._host)
+            if self._hass == None:
+                self._hass = hass
+                hass.loop.create_task(self._readNext())
+                hass.loop.create_task(self._ping())
+
+        @property
+        def host(self):
+            return self._host
+
+    OUTPUT = casetify.Casetify.OUTPUT
+    DEVICE = casetify.Casetify.DEVICE
+
+    Action = casetify.Casetify.Action
+    Button = casetify.Casetify.Button
+
+    def __init__(self, host):
+        instance = None
+        if host in Caseta.__Caseta._hosts:
+            instance = Caseta.__Caseta._hosts[host]
+        else:
+            instance = Caseta.__Caseta(host)
+            Caseta.__Caseta._hosts[host] = instance
+        super(Caseta, self).__setattr__("instance", instance)
+
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+
+    def __setattr__(self, name, value):
+        setattr(self.instance, name, value)

--- a/custom_components/caseta/casetify.py
+++ b/custom_components/caseta/casetify.py
@@ -1,0 +1,125 @@
+import asyncio
+import re
+import logging
+from enum import IntEnum
+
+READ_SIZE = 1024
+DEFAULT_USER = b"lutron"
+DEFAULT_PASSWORD = b"integration"
+CASETA_RE = re.compile(b"~([A-Z]+),([0-9.]+),([0-9.]+),([0-9.]+)\r\n")
+
+_LOGGER = logging.getLogger(__name__)
+
+class Casetify:
+    """Async class to communicate with Lutron Caseta"""
+    loop = asyncio.get_event_loop()
+
+    OUTPUT = "OUTPUT"
+    DEVICE = "DEVICE"
+
+    class Action(IntEnum):
+        SET = 1
+
+    class Button(IntEnum):
+        DOWN = 3
+        UP = 4
+
+    class State(IntEnum):
+        Closed = 1,
+        Opening = 2,
+        Opened = 3
+
+    def __init__(self):
+        self._readbuffer = b""
+        self._readlock = asyncio.Lock()
+        self._writelock = asyncio.Lock()
+        self._state = Casetify.State.Closed
+
+    @asyncio.coroutine
+    def open(self, host, port=23, username=DEFAULT_USER, password=DEFAULT_PASSWORD):
+        with (yield from self._readlock):
+            with (yield from self._writelock):
+                if self._state != Casetify.State.Closed:
+                    return
+                self._state = Casetify.State.Opening
+
+                self._host = host
+                self._port = port
+                self._username = username
+                self._password = password
+
+                self.reader, self.writer = yield from asyncio.open_connection(host, port, loop=Casetify.loop)
+                yield from self._readuntil(b"login: ")
+                self.writer.write(username + b"\r\n")
+                yield from self._readuntil(b"password: ")
+                self.writer.write(password + b"\r\n")
+                yield from self._readuntil(b"GNET> ")
+
+                self._state = Casetify.State.Opened
+
+    @asyncio.coroutine
+    def _readuntil(self, value):
+        while True:
+            if hasattr(value, "search"):
+                # assume regular expression
+                m = value.search(self._readbuffer)
+                if m:
+                    self._readbuffer = self._readbuffer[m.end():]
+                    return m
+            else:
+                where = self._readbuffer.find(value)
+                if where != -1:
+                    self._readbuffer = self._readbuffer[where + len(value):]
+                    return True
+            try:
+                self._readbuffer += yield from self.reader.read(READ_SIZE)
+            except ConnectionResetError as exc:
+                return False
+
+    @asyncio.coroutine
+    def read(self):
+        with (yield from self._readlock):
+            if self._state != Casetify.State.Opened:
+                return None, None, None, None
+            match = yield from self._readuntil(CASETA_RE)
+            if match != False:
+                # 1 = mode, 2 = integration number, 3 = action number, 4 = value
+                try:
+                    return match.group(1).decode("utf-8"), int(match.group(2)), int(match.group(3)), float(match.group(4))
+                except:
+                    print("exception in ", match.group(0))
+        if match == False:
+            # attempt to reconnect
+            _LOGGER.info("Reconnecting to caseta bridge %s", self._host)
+            self._state = Casetify.State.Closed
+            yield from self.open(self._host, self._port, self._username, self._password)
+        return None, None, None, None
+
+    @asyncio.coroutine
+    def write(self, mode, integration, action, value, *args):
+        if hasattr(action, "value"):
+            action = action.value
+        with (yield from self._writelock):
+            if self._state != Casetify.State.Opened:
+                return
+            data = "#{},{},{},{}".format(mode, integration, action, value)
+            for arg in args:
+                if arg != None:
+                    data += ",{}".format(arg)
+            self.writer.write((data + "\r\n").encode())
+
+    @asyncio.coroutine
+    def query(self, mode, integration, action):
+        if hasattr(action, "value"):
+            action = action.value
+        with (yield from self._writelock):
+            if self._state != Casetify.State.Opened:
+                return
+            self.writer.write("?{},{},{}\r\n".format(mode, integration, action).encode())
+
+    @asyncio.coroutine
+    def ping(self):
+        with (yield from self._writelock):
+            if self._state != Casetify.State.Opened:
+                return
+            self.writer.write(b"?SYSTEM,10\r\n")

--- a/custom_components/light/caseta.py
+++ b/custom_components/light/caseta.py
@@ -1,0 +1,137 @@
+"""
+Platform for Caseta lights.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/light.caseta/
+"""
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_TRANSITION, SUPPORT_BRIGHTNESS, SUPPORT_TRANSITION, Light)
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_DEVICES, CONF_HOST, CONF_TYPE)
+import homeassistant.helpers.config_validation as cv
+
+from custom_components import caseta
+
+import voluptuous as vol
+import asyncio
+import logging
+
+DEFAULT_TYPE = "dimmer"
+
+_LOGGER = logging.getLogger(__name__)
+
+class CasetaData:
+    def __init__(self, caseta):
+        self._caseta = caseta
+        self._devices = []
+
+    @property
+    def devices(self):
+        return self._devices
+
+    @property
+    def caseta(self):
+        return self._caseta
+
+    def setDevices(self, devices):
+        self._devices = devices
+
+    @asyncio.coroutine
+    def readOutput(self, mode, integration, action, value):
+        # find integration in devices
+        if mode == caseta.Caseta.OUTPUT:
+            _LOGGER.debug("Got light caseta value: %s %d %d %f", mode, integration, action, value)
+            for device in self._devices:
+                if device.integration == integration:
+                    if action == caseta.Caseta.Action.SET:
+                        _LOGGER.info("Found light device, updating value")
+                        device._update_state(value)
+                        yield from device.async_update_ha_state()
+                        break
+
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the platform."""
+    if discovery_info == None:
+        return
+    bridge = caseta.Caseta(discovery_info[CONF_HOST])
+    yield from bridge.open()
+
+    data = CasetaData(bridge)
+    devices = [CasetaLight(light, data) for light in discovery_info[CONF_DEVICES]]
+    data.setDevices(devices)
+
+    for device in devices:
+        yield from device.query()
+
+    async_add_devices(devices)
+
+    bridge.register(data.readOutput)
+    bridge.start(hass)
+
+    return True
+
+class CasetaLight(Light):
+    """Representation of a Caseta Light."""
+
+    def __init__(self, light, data):
+        """Initialize a Caseta Light."""
+        self._data = data
+        self._name = light["name"]
+        self._integration = int(light["id"])
+        self._is_dimmer = light["type"] == "dimmer"
+        self._is_on = False
+        self._brightness = 0
+
+    @asyncio.coroutine
+    def query(self):
+        yield from self._data.caseta.query(caseta.Caseta.OUTPUT, self._integration, caseta.Caseta.Action.SET)
+
+    @property
+    def integration(self):
+        return self._integration
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Brightness of the light (an integer in the range 1-255)."""
+        return (self._brightness / 100) * 255
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._is_on
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return (SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION) if self._is_dimmer else 0
+
+    def async_turn_on(self, **kwargs):
+        """Instruct the light to turn on."""
+        value = 100
+        transition = None
+        if self._is_dimmer:
+            if ATTR_BRIGHTNESS in kwargs:
+                value = (kwargs[ATTR_BRIGHTNESS] / 255) * 100
+            if ATTR_TRANSITION in kwargs:
+                transition = ":" + str(kwargs[ATTR_TRANSITION])
+        _LOGGER.debug("Writing caseta value: %d %d %d %s", self._integration, caseta.Caseta.Action.SET, value, str(transition))
+        yield from self._data.caseta.write(caseta.Caseta.OUTPUT, self._integration, caseta.Caseta.Action.SET, value, transition)
+
+    def async_turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        transition = None
+        if self._is_dimmer:
+            if ATTR_TRANSITION in kwargs:
+                transition = ":" + str(kwargs[ATTR_TRANSITION])
+        _LOGGER.debug("Writing caseta value: %d %d off %s", self._integration, caseta.Caseta.Action.SET, str(transition))
+        yield from self._data.caseta.write(caseta.Caseta.OUTPUT, self._integration, caseta.Caseta.Action.SET, 0, transition)
+
+    def _update_state(self, brightness):
+        """Update brightness value."""
+        if self._is_dimmer:
+            self._brightness = brightness
+        self._is_on = brightness > 0

--- a/custom_components/sensor/caseta.py
+++ b/custom_components/sensor/caseta.py
@@ -1,0 +1,134 @@
+"""
+Platform for Caseta sensor.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/sensor.caseta/
+"""
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_DEVICES, CONF_HOST)
+import homeassistant.helpers.config_validation as cv
+
+from custom_components import caseta
+
+import voluptuous as vol
+import asyncio
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+class CasetaData:
+    def __init__(self, caseta, hass):
+        self._caseta = caseta
+        self._hass = hass
+        self._devices = []
+        self._added = {}
+        self._later = None
+
+    @property
+    def devices(self):
+        return self._devices
+
+    @property
+    def caseta(self):
+        return self._caseta
+
+    def setDevices(self, devices):
+        self._devices = devices
+
+    @asyncio.coroutine
+    def _checkAdded(self):
+        yield from asyncio.sleep(15)
+        _LOGGER.debug("Checking caseta added")
+        for integration in self._added:
+            _LOGGER.debug("Removing caseta added %d %d", integration, self._added[integration])
+            for device in self._devices:
+                if device.integration == integration:
+                    device._update_state(device.state & ~self._added[integration])
+                    yield from device.async_update_ha_state()
+                    _LOGGER.debug("Removed caseta added %d %d", integration, self._added[integration])
+                    break
+        self._added.clear()
+
+    @asyncio.coroutine
+    def readOutput(self, mode, integration, action, value):
+        # find integration in devices
+        if mode == caseta.Caseta.DEVICE:
+            _LOGGER.debug("Got sensor caseta value: %s %d %d %f", mode, integration, action, value)
+            for device in self._devices:
+                if device.integration == integration:
+                    state = 1 << action - device.minbutton
+                    _LOGGER.debug("Found device, updating value")
+                    if value == caseta.Caseta.Button.DOWN:
+                        _LOGGER.info("Found sensor device, updating value, down")
+                        device._update_state(device.state | state)
+                        if integration in self._added:
+                            self._added[integration] |= state
+                        else:
+                            self._added[integration] = state
+                        if self._later != None:
+                            self._later.cancel()
+                        _LOGGER.debug("scheduling call later")
+                        self._later = self._hass.loop.create_task(self._checkAdded())
+                        yield from device.async_update_ha_state()
+                    elif value == caseta.Caseta.Button.UP:
+                        _LOGGER.info("Found sensor device, updating value, up")
+                        device._update_state(device.state & ~state)
+                        if integration in self._added:
+                            self._added[integration] &= ~state
+                        yield from device.async_update_ha_state()
+                    break
+
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the platform."""
+    if discovery_info == None:
+        return
+    bridge = caseta.Caseta(discovery_info[CONF_HOST])
+    yield from bridge.open()
+
+    data = CasetaData(bridge, hass)
+    devices = [CasetaPicoRemote(pico, data) for pico in discovery_info[CONF_DEVICES]]
+    data.setDevices(devices)
+
+    async_add_devices(devices)
+
+    bridge.register(data.readOutput)
+    bridge.start(hass)
+
+    return True
+
+class CasetaPicoRemote(Entity):
+    """Representation of a Caseta Pico remote."""
+
+    def __init__(self, pico, data):
+        """Initialize a Caseta Pico."""
+        self._data = data
+        self._name = pico['name']
+        self._integration = int(pico['id'])
+        self._buttons = pico['buttons']
+        self._minbutton = 100
+        for b in self._buttons:
+            if b < self._minbutton:
+                self._minbutton = b
+        self._state = 0
+
+    @property
+    def integration(self):
+        return self._integration
+
+    @property
+    def name(self):
+        """Return the display name of this pico."""
+        return self._name
+
+    @property
+    def minbutton(self):
+        return self._minbutton
+
+    @property
+    def state(self):
+        """State of the pico device."""
+        return self._state
+
+    def _update_state(self, state):
+        """Update state."""
+        self._state = state

--- a/custom_components/switch/caseta.py
+++ b/custom_components/switch/caseta.py
@@ -1,0 +1,111 @@
+"""
+Platform for Caseta switches.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/switch.caseta/
+"""
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_DEVICES, CONF_HOST)
+import homeassistant.helpers.config_validation as cv
+
+from custom_components import caseta
+
+import voluptuous as vol
+import asyncio
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+class CasetaData:
+    def __init__(self, caseta):
+        self._caseta = caseta
+        self._devices = []
+
+    @property
+    def devices(self):
+        return self._devices
+
+    @property
+    def caseta(self):
+        return self._caseta
+
+    def setDevices(self, devices):
+        self._devices = devices
+
+    @asyncio.coroutine
+    def readOutput(self, mode, integration, action, value):
+        # find integration in devices
+        if mode == caseta.Caseta.OUTPUT:
+            _LOGGER.debug("Got switch caseta value: %s %d %d %f", mode, integration, action, value)
+            for device in self._devices:
+                if device.integration == integration:
+                    if action == caseta.Caseta.Action.SET:
+                        _LOGGER.info("Found switch device, updating value")
+                        device._update_state(value)
+                        yield from device.async_update_ha_state()
+                        break
+
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the platform."""
+    if discovery_info == None:
+        return
+    bridge = caseta.Caseta(discovery_info[CONF_HOST])
+    yield from bridge.open()
+
+    data = CasetaData(bridge)
+    devices = [CasetaSwitch(switch, data) for switch in discovery_info[CONF_DEVICES]]
+    data.setDevices(devices)
+
+    for device in devices:
+        yield from device.query()
+
+    async_add_devices(devices)
+
+    bridge.register(data.readOutput)
+    bridge.start(hass)
+
+    return True
+
+class CasetaSwitch(SwitchDevice):
+    """Representation of a Caseta Switch."""
+
+    def __init__(self, switch, data):
+        """Initialize a Caseta Switch."""
+        self._data = data
+        self._name = switch['name']
+        self._integration = int(switch['id'])
+        self._is_on = False
+
+    @asyncio.coroutine
+    def query(self):
+        self._data.caseta.query(caseta.Caseta.OUTPUT, self._integration, caseta.Caseta.Action.SET)
+
+    @property
+    def integration(self):
+        return self._integration
+
+    @property
+    def name(self):
+        """Return the display name of this switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._is_on
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Instruct the switch to turn on."""
+        _LOGGER.debug("Writing caseta value: %d %d on", self._integration, caseta.Caseta.Action.SET)
+        yield from self._data.caseta.write(caseta.Caseta.OUTPUT, self._integration, caseta.Caseta.Action.SET, 100)
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Instruct the swtich to turn off."""
+        _LOGGER.debug("Writing caseta value: %d %d off", self._integration, caseta.Caseta.Action.SET)
+        yield from self._data.caseta.write(caseta.Caseta.OUTPUT, self._integration, caseta.Caseta.Action.SET, 0)
+
+    def _update_state(self, value):
+        """Update state."""
+        self._is_on = value > 0

--- a/groups.yaml
+++ b/groups.yaml
@@ -65,6 +65,7 @@ kitchen:
   - light.fridge_lights
   - light.island
   - light.island_2
+  - light.table_lights
 
 stairwell:
   name: Stairwell

--- a/scripts.yaml
+++ b/scripts.yaml
@@ -15,6 +15,7 @@ turn_on_upstairs:
   - service: light.turn_on
     entity_id:
     - light.lamp_dimmer_one_level  # Blinky
+    - light.table_lights  # Dining room table
     data:
       brightness: 75
       profile: relax


### PR DESCRIPTION
This is how I got everything working with my new Caseta Pro hub.

1. Grab the files from this repository and place them in your `/.homeassistant/custom_components` directories....
https://github.com/ksheumaker/ha-caseta-pro
1. In your Lutron mobile app:
    - Settings
    - Advanced
    - Integration
    - Turn on "Telnet support"
    - Use the "Send Integration Report" option to email yourself a copy of the integration JSON
1. Once you have the Integration Report, place the JSON file in a `/.homeassistant/caseta_[Lutron bridge IP address].json` file
1. Add the following to your `/.homeassistant/configuration.yaml` file. You have to manually identify any on/off switches as such or everything will be treated as as a dimmer. You can find these Device IDs from the Integration JSON file.
```
caseta:
  bridges:
    - host: [Lutron bridge IP address]
      devices:
        - id: 2
          type: switch
        - id: 3
          type: switch
```